### PR TITLE
Fix render, Rework Preview & Activate Scene

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
 

--- a/src/scripts/api.js
+++ b/src/scripts/api.js
@@ -14,21 +14,18 @@ const API = {
     this.executeAction(options);
   },
   executeAction(options) {
-    if (options.action) {
-      switch (options.action) {
-        case "end": {
-          SceneTransition.activeTransition.destroy();
-          break;
-        }
-        default: {
-          break;
-        }
-      }
-    } else {
-      // Run a transition
-      let activeTransition = new SceneTransition(false, options, undefined);
-      activeTransition.render();
+    let activeTransition = SceneTransition.activeTransition;
+
+    if (activeTransition) {
+      SceneTransition.activeTransition.destroy(true);
     }
+
+    if (options?.action == "end") {
+      return;
+    }
+
+    activeTransition = new SceneTransition(false, options, undefined);
+    activeTransition.render();
   },
   async macroArr(...inAttributes) {
     if (!Array.isArray(inAttributes)) {


### PR DESCRIPTION
- Fixed scene transition not appearing on first attempt. This was due to the `render` method looking for a non-existent HTML element. I've also reworked the `render` method, breaking it down into further methods and swapping the jQuery for vanilla JS in most cases.
- Reworked how the 'Preview' and 'Activate Scene for Everyone' options work, though I may have misunderstood their original purpose, so please review and let me know. I've reworked it as the following:

1. If 'Preview' is enabled, the scene transition will play for everyone, but the scene will not be activated for anyone including the GM.
2. If 'Activate Scene for Everyone' is enabled, the scene transition will play for everyone and the scene will be activated for everyone.
3. If both options are disabled, the scene transition will play for everyone and the scene will be viewed by the GM only.