### PR TITLE
Respect fade-out settings for GM-prompted transition closure

### DIFF
--- a/src/scripts/api.js
+++ b/src/scripts/api.js
@@ -20,9 +20,12 @@ async function executeActionArr(...inAttributes) {
  * @returns
  */
 async function executeAction(options) {
-    await SceneTransition?.activeTransition?.destroy();
-
-    if (options?.action == "end") return;
+    if (options?.action == "end") {
+        await SceneTransition?.activeTransition?.destroy();
+        return;
+    } else {
+        await SceneTransition?.activeTransition?.destroy(true);
+    }
 
     const sceneTransition = new SceneTransition(false, options, undefined);
     sceneTransition.render();

--- a/src/scripts/api.js
+++ b/src/scripts/api.js
@@ -20,7 +20,7 @@ async function executeActionArr(...inAttributes) {
  * @returns
  */
 async function executeAction(options) {
-    await SceneTransition?.activeTransition?.destroy(true);
+    await SceneTransition?.activeTransition?.destroy();
 
     if (options?.action == "end") return;
 


### PR DESCRIPTION
Currently because of the explicit true, GM closure of a transition scene instantly closes it regardless of settings - this PR amends this, allowing for clean fadeouts for everybody. I did this because I prefer to keep a ludicrously long duration (basically indefinite) and close the transition after I'm done narrating. Tested it out a bunch locally and couldn't find any issues, though further poking and prodding is always appreciated 👍 