### PR TITLE
feat: update to work with foundry v13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 13.0.0
+
+- Updated for FoundryVTT v13 compatibility
+
 ### 12.0.1
 
 - Bug fix: https://github.com/p4535992/foundryvtt-scene-transitions/issues/39#issuecomment-2425044453 ty to @Conradhowlf

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "scene-transitions",
 	"title": "Scene Transitions",
 	"description": "Create transition between scenes. Or show a Slide from a Journal or Macro for Narration",
-	"version": "12.0.0",
+	"version": "13.0.0",
 	"main": "module.js",
 	"license": "SEE LICENSE IN LICENSE",
 	"private": true,

--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
     "id": "scene-transitions",
     "title": "Scene Transitions",
     "description": "Create transition between scenes. Or show a Slide from a Journal or Macro for Narration",
-    "version": "12.0.1",
+    "version": "13.0.0",
     "authors": [
         {
             "name": "Larkinabout",
@@ -66,9 +66,8 @@
     "esmodules": ["module.js"],
     "styles": ["styles/scene-transitions.css"],
     "compatibility": {
-        "minimum": 11,
-        "verified": 12,
-        "maximum": 12
+        "minimum": 13,
+        "verified": 13.346
     },
     "url": "https://github.com/p4535992/foundryvtt-scene-transitions",
     "manifest": "https://github.com/p4535992/foundryvtt-scene-transitions/releases/download/12.0.1/module.json",

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -25,7 +25,9 @@ export class Utils {
         if (!content) return null;
         const parser = new DOMParser();
         const doc = parser.parseFromString(content, "text/html");
-        const src = doc.querySelector("img").getAttribute("src");
+        const imgElement = doc.querySelector("img");
+        if (!imgElement) return null;
+        const src = imgElement.getAttribute("src");
         return src || null;
     }
 


### PR DESCRIPTION
Closes: #44 

Hi! I've not used this before, but would very much like to. These changes have worked for me to get it running on Foundry v13, with the largest change coming from the fixes to support the journal entries.

A test release is available on my fork if you want to play with it.

<img width="1537" height="644" alt="2025-08-12T23:45:07,902752396-07:00" src="https://github.com/user-attachments/assets/f94f0fd8-948e-4c3d-8d1d-a67b0969a720" />
Menu appears for scenes on right click, edit menu comes up, and confirmation of Foundry version I tested on.

<img width="790" height="311" alt="2025-08-12T23:47:46,670125484-07:00" src="https://github.com/user-attachments/assets/de07e113-ca3a-47b1-ac28-b8c2f46c1584" />
Play from journal works, and comes up with a selection box if there are multiple pages

<img width="1056" height="455" alt="2025-08-12T23:47:10,560602213-07:00" src="https://github.com/user-attachments/assets/a08f690e-bc71-4bc3-8f18-019fb37cb1f5" />
Inside a journal play transition works when right clicking on a journal entry.



